### PR TITLE
🐛 Fix: Uses a tab instead of spaces for cz inquirer prompt

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -23,7 +23,7 @@ module.exports = function (options) {
   var choices = map(types, function (type, key) {
     var name = type.name || key;
     return {
-      name: type.emoji + '  ' + rightPad(name + ':', length) + ' ' + type.description,
+      name: type.emoji + '\t' + rightPad(name + ':', length) + ' ' + type.description,
       value: {
         emoji: type.emoji,
         name: name,


### PR DESCRIPTION
In the original design, we used two spaces to pad the emoji. Unfortunately, many emoji are now multi-character width and can cause alignment issues in the inquirer prompt list. By changes from spaces to a tab character, we can ensure a clean alignment in the inquirer list without affecting the commit itself.

**Alignment Before** _notice how the recycle icon is off by a single monospace character_
![Screenshot 2020-02-28 11 13 19](https://user-images.githubusercontent.com/1795/75579820-79111180-5a1b-11ea-90ff-83b141dd011f.png)

**Alignment After**
![Screenshot 2020-02-28 11 12 56](https://user-images.githubusercontent.com/1795/75579842-81694c80-5a1b-11ea-8c8f-2244f85d5bc9.png)
